### PR TITLE
Cloudflare 3.x.x throwing ModuleNotFound error

### DIFF
--- a/ghostbuster/scan.py
+++ b/ghostbuster/scan.py
@@ -17,7 +17,7 @@ from .__init__ import Info, pass_info
 import boto3
 import base64
 import json as json_lib
-import CloudFlare
+import cloudFlare
 import awsipranges
 from slack_sdk.webhook import WebhookClient
 from botocore.exceptions import ClientError

--- a/ghostbuster/scan.py
+++ b/ghostbuster/scan.py
@@ -17,7 +17,7 @@ from .__init__ import Info, pass_info
 import boto3
 import base64
 import json as json_lib
-import cloudFlare
+import cloudflare
 import awsipranges
 from slack_sdk.webhook import WebhookClient
 from botocore.exceptions import ClientError


### PR DESCRIPTION
- On 25.6 cloudflare changed their module to be lowercase, which is causing issues when importing from `ghostbuster/scan.py`
- Just changing capitalisation fixes this
- Tested it locally, no issues during imports