### PR TITLE
Add requests to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ boto3
 cloudflare
 awsipranges
 slack_sdk
+requests


### PR DESCRIPTION
ghostbuster [assumes requests is installed](https://github.com/assetnote/ghostbuster/blob/master/ghostbuster/scan.py#L14) but doesn't specify as much in its requirements.txt.